### PR TITLE
Fix image source path for ZONES logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ZONES
 
 <p >
-  <img src="./src/assets/Zones.png" alt="ZONES logo" width="720">
+  <img src="./app/src/assets/Zones.png" alt="ZONES logo" width="720">
 </p>
 
 <p >


### PR DESCRIPTION
Updated image source path for ZONES logo in README.

## Summary by Sourcery

Documentation:
- Adjust the README ZONES logo image reference to use the updated asset path.